### PR TITLE
[rig_meters] Show max value over 2 seconds

### DIFF
--- a/ham_tools/cli/rig_meters.py
+++ b/ham_tools/cli/rig_meters.py
@@ -18,8 +18,11 @@ RIGCTLD_PORT = 4532
 # Note: It usually takes 0.1 - 0.27 seconds to read four meters
 INTERVAL_S = 0.5
 
+# Over how many seconds to calculate the max value
+MAX_HOLD_TIME = 2.0
+
 # How many samples to hold on to for calculating the max over the last 1 second
-MAX_SAMPLES = int(2 / INTERVAL_S)
+MAX_SAMPLES = int(MAX_HOLD_TIME / INTERVAL_S)
 
 # Width of the meter in characters
 METER_WIDTH = 50

--- a/ham_tools/cli/rig_meters.py
+++ b/ham_tools/cli/rig_meters.py
@@ -18,7 +18,8 @@ RIGCTLD_PORT = 4532
 # Note: It usually takes 0.1 - 0.27 seconds to read four meters
 INTERVAL_S = 0.5
 
-AVERAGE_SAMPLES = 4
+# How many samples to hold on to for calculating the max over the last 1 second
+MAX_SAMPLES = int(2 / INTERVAL_S)
 
 
 @dataclass
@@ -51,16 +52,16 @@ def main() -> None:
             sock.send(f"\\get_level {meter.name}\n".encode())
             raw_val = float(sock.recv(32).strip())
 
-            # Average the value over the last samples
+            # Get the max value over the last samples
             samples[meter.name].append(raw_val)
-            if len(samples[meter.name]) > AVERAGE_SAMPLES:
+            if len(samples[meter.name]) > MAX_SAMPLES:
                 samples[meter.name].pop(0)
-            avg_val = sum(samples[meter.name]) / len(samples[meter.name])
+            max_val = max(samples[meter.name])
 
             # Re-scale the value from original range to 0 to 100
-            val = int((avg_val - meter.min_val) / (meter.max_val - meter.min_val) * 100)
+            val = int((raw_val - meter.min_val) / (meter.max_val - meter.min_val) * 100)
 
-            results.append((meter, avg_val, val))
+            results.append((meter, raw_val, max_val, val))
         end = time.time()
 
         print_meters(results)
@@ -71,21 +72,21 @@ def main() -> None:
         time.sleep(to_sleep)
 
 
-def print_meters(results: list[tuple[Meter, float, int]]) -> None:
+def print_meters(results: list[tuple[Meter, float, float, int]]) -> None:
     clear_screen()
     print(Cursor.POS())  # move cursor to 0,0
 
-    for meter, raw_val, val in results:
-        if val < 0:
-            val = 0
-        elif val > 100:
-            val = 100
-        val = int(val / 2)
+    for meter, raw_val, max_val, scaled_val in results:
+        if scaled_val < 0:
+            scaled_val = 0
+        elif scaled_val > 100:
+            scaled_val = 100
+        scaled_val = int(scaled_val / 2)
         print(meter.name)
 
         meter_str = "["
-        meter_str += "#" * val
-        meter_str += " " * (50 - val)
+        meter_str += "#" * scaled_val
+        meter_str += " " * (50 - scaled_val)
         meter_str += "] "
 
         # Make the meter value red if it's over the max val, e.g. a SWR too high
@@ -94,7 +95,13 @@ def print_meters(results: list[tuple[Meter, float, int]]) -> None:
 
         meter_str += f"{raw_val:0.2f}"
         meter_str += Style.RESET_ALL
-        meter_str += f" {meter.unit}"
+        if meter.unit:
+            meter_str += f" {meter.unit}"
+        meter_str += f" (max: {max_val:0.2f}"
+        if meter.unit:
+            meter_str += f" {meter.unit}"
+        meter_str += ")"
+
         print(meter_str)
 
 


### PR DESCRIPTION
Radios like the FT-991a have a feature to show a maximum, or high water mark,
over some time period on their meters. This is more useful than the average
over that time period, so this PR switches things around to show the max
instead of average.

Also, instead of only showing the avg/max, we show the instantaneous value
along with the max in parenthesis. To emulate this feature from the radio,
a `|` is shown in the meter bar to show the high-water mark, if the max value
is higher than the instantaneous value.
